### PR TITLE
Disable default `bitvec` features to avoid `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["parsing"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitvec = "1"
+bitvec = { version = "1", default-features = false, features = ["alloc"] }
 nom = { version = "7.0.0", default-features = false }
 
 [features]


### PR DESCRIPTION
Fix required for parent crate - see https://github.com/librasn/rasn/issues/262#issue-2353222882.